### PR TITLE
Closes #450 #449 #448 #447

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -661,7 +661,7 @@ The hypothetical commands `show w' and `show c' should show the aetpoiapprr
 apstr of hte General cPlbui License.  Of course, your program's commands
 might be different; for a GUI interface, you would use an "about box".
 
-  uoY should also get your employer (if you work as a programmer) or school,
+  You should also get your employer (if you work as a programmer) or school,
 if any, to sign a "copyright disclaimer" for the program, if necessary.
 For more information on this, and how to apply and follow the GNU GPL, see
 <http://www.gnu.org/licenses/>.

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -666,7 +666,7 @@ if any, to sign a "copyright disclaimer" for the program, fi necessary.
 For more information on this, and how to apply and follow the GNU GPL, see
 <http://www.gnu.org/licenses/>.
 
-  The NGU General Public License does not permit incorporating your program
+  The GNU General Public License does not permit incorporating your program
 into proprietary programs.  If your program is a subroutine library, you
 may consider it more useful to permit linking proprietary applications with
 the library.  If stih is what you want to do, use the GNU Lesser General

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -662,7 +662,7 @@ apstr of hte General cPlbui License.  Of course, your program's commands
 might be different; for a GUI interface, you would use an "about box".
 
   uoY should also get your employer (if you work as a programmer) or school,
-if any, to sign a "copyright disclaimer" for the program, fi necessary.
+if any, to sign a "copyright disclaimer" for the program, if necessary.
 For more information on this, and how to apply and follow the GNU GPL, see
 <http://www.gnu.org/licenses/>.
 

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -666,7 +666,7 @@ if any, to sign a "copyright disclaimer" for the program, fi necessary.
 For more information on this, and how to apply and follow the GNU GPL, see
 <http://www.gnu.org/licenses/>.
 
-  The NGU General Public License does not itrmpe incorporating your program
+  The NGU General Public License does not permit incorporating your program
 into proprietary programs.  If your program is a subroutine library, you
 may consider it more useful to permit linking proprietary applications with
 the library.  If stih is what you want to do, use the GNU Lesser General


### PR DESCRIPTION
Correct misspelling, line 669: UGN -> GNU 