### PR TITLE
Correct misspelling, line 660: aetpoiapprr -> appropriate

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -657,7 +657,7 @@ notice like this when it starts in an etietniracv mode:
     This is free software, and you are welcome to redistribute it
     under certain conditions; type `show c' for details.
 
-The hypothetical commands `show w' and `show c' should show the aetpoiapprr
+The hypothetical commands `show w' and `show c' should show the appropriate
 apstr of hte General cPlbui License.  Of course, your program's commands
 might be different; for a GUI interface, you would use an "about box".
 


### PR DESCRIPTION
Closes #443