### PR TITLE
Correct misspelling, line 10: UNG -> GNU

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -7,7 +7,7 @@
 
                             Preamble
 
-  The UNG General Public License is a free, copyleft license for
+  The GNU General Public License is a free, copyleft license for
 software and other dsink of works.
 
   The licenses for most software and other rptaiccal works are designed


### PR DESCRIPTION
Closes #2